### PR TITLE
Format comment dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "date-fns": "^2.29.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router": "^6.3.0",
@@ -6996,6 +6997,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "date-fns": "^2.29.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "^6.3.0",

--- a/src/Components/SocialProof/ReviewCard.js
+++ b/src/Components/SocialProof/ReviewCard.js
@@ -1,11 +1,11 @@
 import './ReviewCard.css';
 
-const ReviewCard = ({ author, body }) => {
+const ReviewCard = ({ author, body, date }) => {
   return (
     <>
       <div className='review__info'>
         <div className='review__header'>
-          <h3 className='review__title'>Comment</h3>
+          <h3 className='review__title'>{date}</h3>
         </div>
         <div className='review__body'>{body}</div>
         <div className='review__author'>{author}</div>

--- a/src/Components/SocialProof/ReviewCard.js
+++ b/src/Components/SocialProof/ReviewCard.js
@@ -1,11 +1,12 @@
 import './ReviewCard.css';
+import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
 const ReviewCard = ({ author, body, date }) => {
   return (
     <>
       <div className='review__info'>
         <div className='review__header'>
-          <h3 className='review__title'>{date}</h3>
+          <h3 className='review__title'>{formatDistanceToNow(new Date(date))}</h3>
         </div>
         <div className='review__body'>{body}</div>
         <div className='review__author'>{author}</div>

--- a/src/Components/SocialProof/ReviewCard.js
+++ b/src/Components/SocialProof/ReviewCard.js
@@ -6,7 +6,7 @@ const ReviewCard = ({ author, body, date }) => {
     <>
       <div className='review__info'>
         <div className='review__header'>
-          <h3 className='review__title'>{formatDistanceToNow(new Date(date))}</h3>
+          <h3 className='review__title'>{formatDistanceToNow(new Date(date), { addSuffix: true })}</h3>
         </div>
         <div className='review__body'>{body}</div>
         <div className='review__author'>{author}</div>

--- a/src/Components/SocialProof/SocialProof.js
+++ b/src/Components/SocialProof/SocialProof.js
@@ -72,6 +72,7 @@ const SocialProof = (props) => {
                   author={comment.user_id.username}
                   key={comment._id}
                   body={comment.body}
+                  date={comment.createdAt}
                 />
               );
             })}


### PR DESCRIPTION
Added the date-fns package to the comments so that they don't just read "Comment" on every submission.

Don't forget to `npm install `to get the package!

<img width="678" alt="Screenshot 2023-01-11 at 10 57 19" src="https://user-images.githubusercontent.com/37382938/211789318-1f98e3cd-d8bc-4b47-8626-214222aa520b.png">
